### PR TITLE
Expose runtime WS2812 debug controls via keymap

### DIFF
--- a/qmk_porting/drivers/ws2812/ws2812_pwm.c
+++ b/qmk_porting/drivers/ws2812/ws2812_pwm.c
@@ -1,6 +1,7 @@
 #include "quantum.h"
 #include "ws2812.h"
 #include "ws2812_supplement.h"
+#include "print.h"
 
 /*
  * Dual PWM/DMA WS2812 driver for CH582M.
@@ -10,66 +11,67 @@
  */
 
 #ifdef WS2812_RGBW
-#    define WS2812_CHANNELS 4
+#define WS2812_CHANNELS 4
 #else
-#    define WS2812_CHANNELS 3
+#define WS2812_CHANNELS 3
 #endif
 
 #ifndef WS2812_PWM_DRIVER_1
-#    define WS2812_PWM_DRIVER_1 1
-#    define WS2812_DI_PIN_1 A10
-#    define WS2812_LED_COUNT_1 50
+#define WS2812_PWM_DRIVER_1 1
+#define WS2812_DI_PIN_1     A10
+#define WS2812_LED_COUNT_1  50
 #endif
 
 #ifndef WS2812_PWM_DRIVER_2
-#    define WS2812_PWM_DRIVER_2 2
-#    define WS2812_DI_PIN_2 A11
-#    define WS2812_LED_COUNT_2 4
+#define WS2812_PWM_DRIVER_2 2
+#define WS2812_DI_PIN_2     A11
+#define WS2812_LED_COUNT_2  4
 #endif
 
 #define PWM_Times_1 1
 
 #if WS2812_PWM_DRIVER_1 == 1
-#    define WS2812_PWM1_CNT_END_REG R32_TMR1_CNT_END
-#    define WS2812_DMA_CONFIG1(en, start, end) \
-        TMR1_DMACfg(en, (uint16_t)(uint32_t)&start, \
-                    (uint16_t)(uint32_t)&end, Mode_LOOP)
-#    define WS2812_PWM_INIT1(level)          TMR1_PWMInit(level, PWM_Times_1);
-#    define WS2812_PWM_DMA_INTERRUPT_ENABLE1 PFIC_EnableIRQ(TMR1_IRQn);
-#    define WS2812_PWM_DMA_INTERRUPT_SET1    TMR1_ITCfg(ENABLE, RB_TMR_IE_DMA_END);
+#define WS2812_PWM1_CNT_END_REG R32_TMR1_CNT_END
+#define WS2812_DMA_CONFIG1(en, start, end)      \
+    TMR1_DMACfg(en, (uint16_t)(uint32_t)&start, \
+                (uint16_t)(uint32_t)&end, Mode_LOOP)
+#define WS2812_PWM_INIT1(level)          TMR1_PWMInit(level, PWM_Times_1);
+#define WS2812_PWM_DMA_INTERRUPT_ENABLE1 PFIC_EnableIRQ(TMR1_IRQn);
+#define WS2812_PWM_DMA_INTERRUPT_SET1    TMR1_ITCfg(ENABLE, RB_TMR_IE_DMA_END);
 #elif WS2812_PWM_DRIVER_1 == 2
-#    define WS2812_PWM1_CNT_END_REG R32_TMR2_CNT_END
-#    define WS2812_DMA_CONFIG1(en, start, end) \
-        TMR2_DMACfg(en, (uint16_t)(uint32_t)&start, \
-                    (uint16_t)(uint32_t)&end, Mode_LOOP)
-#    define WS2812_PWM_INIT1(level)          TMR2_PWMInit(level, PWM_Times_1);
-#    define WS2812_PWM_DMA_INTERRUPT_ENABLE1 PFIC_EnableIRQ(TMR2_IRQn);
-#    define WS2812_PWM_DMA_INTERRUPT_SET1    TMR2_ITCfg(ENABLE, RB_TMR_IE_DMA_END);
+#define WS2812_PWM1_CNT_END_REG R32_TMR2_CNT_END
+#define WS2812_DMA_CONFIG1(en, start, end)      \
+    TMR2_DMACfg(en, (uint16_t)(uint32_t)&start, \
+                (uint16_t)(uint32_t)&end, Mode_LOOP)
+#define WS2812_PWM_INIT1(level)          TMR2_PWMInit(level, PWM_Times_1);
+#define WS2812_PWM_DMA_INTERRUPT_ENABLE1 PFIC_EnableIRQ(TMR2_IRQn);
+#define WS2812_PWM_DMA_INTERRUPT_SET1    TMR2_ITCfg(ENABLE, RB_TMR_IE_DMA_END);
 #else
-#    error Unsupported PWM driver for strip1
+#error Unsupported PWM driver for strip1
 #endif
 
 #if WS2812_PWM_DRIVER_2 == 1
-#    define WS2812_PWM2_CNT_END_REG R32_TMR1_CNT_END
-#    define WS2812_DMA_CONFIG2(en, start, end) \
-        TMR1_DMACfg(en, (uint16_t)(uint32_t)&start, \
-                    (uint16_t)(uint32_t)&end, Mode_LOOP)
-#    define WS2812_PWM_INIT2(level)          TMR1_PWMInit(level, PWM_Times_1);
-#    define WS2812_PWM_DMA_INTERRUPT_ENABLE2 PFIC_EnableIRQ(TMR1_IRQn);
-#    define WS2812_PWM_DMA_INTERRUPT_SET2    TMR1_ITCfg(ENABLE, RB_TMR_IE_DMA_END);
+#define WS2812_PWM2_CNT_END_REG R32_TMR1_CNT_END
+#define WS2812_DMA_CONFIG2(en, start, end)      \
+    TMR1_DMACfg(en, (uint16_t)(uint32_t)&start, \
+                (uint16_t)(uint32_t)&end, Mode_LOOP)
+#define WS2812_PWM_INIT2(level)          TMR1_PWMInit(level, PWM_Times_1);
+#define WS2812_PWM_DMA_INTERRUPT_ENABLE2 PFIC_EnableIRQ(TMR1_IRQn);
+#define WS2812_PWM_DMA_INTERRUPT_SET2    TMR1_ITCfg(ENABLE, RB_TMR_IE_DMA_END);
 #elif WS2812_PWM_DRIVER_2 == 2
-#    define WS2812_PWM2_CNT_END_REG R32_TMR2_CNT_END
-#    define WS2812_DMA_CONFIG2(en, start, end) \
-        TMR2_DMACfg(en, (uint16_t)(uint32_t)&start, \
-                    (uint16_t)(uint32_t)&end, Mode_LOOP)
-#    define WS2812_PWM_INIT2(level)          TMR2_PWMInit(level, PWM_Times_1);
-#    define WS2812_PWM_DMA_INTERRUPT_ENABLE2 PFIC_EnableIRQ(TMR2_IRQn);
-#    define WS2812_PWM_DMA_INTERRUPT_SET2    TMR2_ITCfg(ENABLE, RB_TMR_IE_DMA_END);
+#define WS2812_PWM2_CNT_END_REG R32_TMR2_CNT_END
+#define WS2812_DMA_CONFIG2(en, start, end)      \
+    TMR2_DMACfg(en, (uint16_t)(uint32_t)&start, \
+                (uint16_t)(uint32_t)&end, Mode_LOOP)
+#define WS2812_PWM_INIT2(level)          TMR2_PWMInit(level, PWM_Times_1);
+#define WS2812_PWM_DMA_INTERRUPT_ENABLE2 PFIC_EnableIRQ(TMR2_IRQn);
+#define WS2812_PWM_DMA_INTERRUPT_SET2    TMR2_ITCfg(ENABLE, RB_TMR_IE_DMA_END);
 #else
-#    error Unsupported PWM driver for strip2
+#error Unsupported PWM driver for strip2
 #endif
 
-__INTERRUPT __HIGH_CODE void TMR1_IRQHandler() {
+__INTERRUPT __HIGH_CODE void TMR1_IRQHandler()
+{
     R8_TMR1_INTER_EN = 0;
     TMR1_ClearITFlag(RB_TMR_IF_DMA_END);
     do {
@@ -79,7 +81,8 @@ __INTERRUPT __HIGH_CODE void TMR1_IRQHandler() {
     } while (!(R8_SLP_CLK_OFF0 & RB_SLP_CLK_TMR1));
 }
 
-__INTERRUPT __HIGH_CODE void TMR2_IRQHandler() {
+__INTERRUPT __HIGH_CODE void TMR2_IRQHandler()
+{
     R8_TMR2_INTER_EN = 0;
     TMR2_ClearITFlag(RB_TMR_IF_DMA_END);
     do {
@@ -90,14 +93,14 @@ __INTERRUPT __HIGH_CODE void TMR2_IRQHandler() {
 }
 
 #ifndef WS2812_PWM_TARGET_PERIOD
-#    define WS2812_PWM_TARGET_PERIOD 80000
+#define WS2812_PWM_TARGET_PERIOD 80000
 #endif
 
 #define WS2812_PWM_FREQUENCY FREQ_SYS
 #define WS2812_PWM_PERIOD    (WS2812_PWM_FREQUENCY / WS2812_PWM_TARGET_PERIOD)
 
-#define WS2812_COLOR_BITS  (WS2812_CHANNELS * 8)
-#define WS2812_RESET_BIT_N (1000 * WS2812_TRST_US / WS2812_TIMING)
+#define WS2812_COLOR_BITS   (WS2812_CHANNELS * 8)
+#define WS2812_RESET_BIT_N  (1000 * WS2812_TRST_US / WS2812_TIMING)
 #define WS2812_COLOR_BIT_N1 (WS2812_LED_COUNT_1 * WS2812_COLOR_BITS)
 #define WS2812_COLOR_BIT_N2 (WS2812_LED_COUNT_2 * WS2812_COLOR_BITS)
 #define WS2812_BIT_N1       (WS2812_COLOR_BIT_N1 + WS2812_RESET_BIT_N)
@@ -109,23 +112,55 @@ __INTERRUPT __HIGH_CODE void TMR2_IRQHandler() {
 #define WS2812_BIT_STRIP(led, byte, bit) (WS2812_COLOR_BITS * (led) + 8 * (byte) + (7 - (bit)))
 
 #if (WS2812_BYTE_ORDER == WS2812_BYTE_ORDER_GRB)
-#    define WS2812_RED_BIT_STRIP(led, bit)   WS2812_BIT_STRIP((led), 1, (bit))
-#    define WS2812_GREEN_BIT_STRIP(led, bit) WS2812_BIT_STRIP((led), 0, (bit))
-#    define WS2812_BLUE_BIT_STRIP(led, bit)  WS2812_BIT_STRIP((led), 2, (bit))
+#define WS2812_RED_BIT_STRIP(led, bit)   WS2812_BIT_STRIP((led), 1, (bit))
+#define WS2812_GREEN_BIT_STRIP(led, bit) WS2812_BIT_STRIP((led), 0, (bit))
+#define WS2812_BLUE_BIT_STRIP(led, bit)  WS2812_BIT_STRIP((led), 2, (bit))
 #elif (WS2812_BYTE_ORDER == WS2812_BYTE_ORDER_RGB)
-#    define WS2812_RED_BIT_STRIP(led, bit)   WS2812_BIT_STRIP((led), 0, (bit))
-#    define WS2812_GREEN_BIT_STRIP(led, bit) WS2812_BIT_STRIP((led), 1, (bit))
-#    define WS2812_BLUE_BIT_STRIP(led, bit)  WS2812_BIT_STRIP((led), 2, (bit))
+#define WS2812_RED_BIT_STRIP(led, bit)   WS2812_BIT_STRIP((led), 0, (bit))
+#define WS2812_GREEN_BIT_STRIP(led, bit) WS2812_BIT_STRIP((led), 1, (bit))
+#define WS2812_BLUE_BIT_STRIP(led, bit)  WS2812_BIT_STRIP((led), 2, (bit))
 #elif (WS2812_BYTE_ORDER == WS2812_BYTE_ORDER_BGR)
-#    define WS2812_RED_BIT_STRIP(led, bit)   WS2812_BIT_STRIP((led), 2, (bit))
-#    define WS2812_GREEN_BIT_STRIP(led, bit) WS2812_BIT_STRIP((led), 1, (bit))
-#    define WS2812_BLUE_BIT_STRIP(led, bit)  WS2812_BIT_STRIP((led), 0, (bit))
+#define WS2812_RED_BIT_STRIP(led, bit)   WS2812_BIT_STRIP((led), 2, (bit))
+#define WS2812_GREEN_BIT_STRIP(led, bit) WS2812_BIT_STRIP((led), 1, (bit))
+#define WS2812_BLUE_BIT_STRIP(led, bit)  WS2812_BIT_STRIP((led), 0, (bit))
 #endif
 
+static rgb_led_t ws2812_last_leds1[WS2812_LED_COUNT_1];
+static rgb_led_t ws2812_last_leds2[WS2812_LED_COUNT_2];
 static uint32_t ws2812_frame_buffer1[WS2812_BIT_N1 + 1];
 static uint32_t ws2812_frame_buffer2[WS2812_BIT_N2 + 1];
 
-static void ws2812_write_led1(uint16_t led_number, uint8_t r, uint8_t g, uint8_t b) {
+#ifdef WS2812_DEBUG
+static bool ws2812_debug_enabled;
+#define ws2812_debug(...)         \
+    do {                          \
+        if (ws2812_debug_enabled) \
+            dprintf(__VA_ARGS__); \
+    } while (0)
+void ws2812_debug_toggle(void)
+{
+    ws2812_debug_enabled = !ws2812_debug_enabled;
+    dprintf("WS2812 debug %s\n", ws2812_debug_enabled ? "on" : "off");
+}
+void ws2812_debug_dump_strip1(void)
+{
+    for (uint16_t i = 0; i < WS2812_LED_COUNT_1; i++) {
+        rgb_led_t c = ws2812_last_leds1[i];
+        dprintf("strip1[%u]=%u,%u,%u\n", i, c.r, c.g, c.b);
+    }
+}
+#else
+#define ws2812_debug(...)
+void ws2812_debug_toggle(void)
+{
+}
+void ws2812_debug_dump_strip1(void)
+{
+}
+#endif
+
+static void ws2812_write_led1(uint16_t led_number, uint8_t r, uint8_t g, uint8_t b)
+{
 #if WS2812_PWM_DRIVER_1 == 1
     do {
         sys_safe_access_enable();
@@ -139,14 +174,19 @@ static void ws2812_write_led1(uint16_t led_number, uint8_t r, uint8_t g, uint8_t
         sys_safe_access_disable();
     } while (R8_SLP_CLK_OFF0 & RB_SLP_CLK_TMR2);
 #endif
+    ws2812_last_leds1[led_number].r = r;
+    ws2812_last_leds1[led_number].g = g;
+    ws2812_last_leds1[led_number].b = b;
+    ws2812_debug("strip1[%u]=%u,%u,%u\n", led_number, r, g, b);
     for (uint8_t bit = 0; bit < 8; bit++) {
-        ws2812_frame_buffer1[WS2812_RED_BIT_STRIP(led_number, bit)]   = ((r >> bit) & 0x01) ? WS2812_DUTYCYCLE_1 : WS2812_DUTYCYCLE_0;
+        ws2812_frame_buffer1[WS2812_RED_BIT_STRIP(led_number, bit)] = ((r >> bit) & 0x01) ? WS2812_DUTYCYCLE_1 : WS2812_DUTYCYCLE_0;
         ws2812_frame_buffer1[WS2812_GREEN_BIT_STRIP(led_number, bit)] = ((g >> bit) & 0x01) ? WS2812_DUTYCYCLE_1 : WS2812_DUTYCYCLE_0;
-        ws2812_frame_buffer1[WS2812_BLUE_BIT_STRIP(led_number, bit)]  = ((b >> bit) & 0x01) ? WS2812_DUTYCYCLE_1 : WS2812_DUTYCYCLE_0;
+        ws2812_frame_buffer1[WS2812_BLUE_BIT_STRIP(led_number, bit)] = ((b >> bit) & 0x01) ? WS2812_DUTYCYCLE_1 : WS2812_DUTYCYCLE_0;
     }
 }
 
-static void ws2812_write_led2(uint16_t led_number, uint8_t r, uint8_t g, uint8_t b) {
+static void ws2812_write_led2(uint16_t led_number, uint8_t r, uint8_t g, uint8_t b)
+{
 #if WS2812_PWM_DRIVER_2 == 1
     do {
         sys_safe_access_enable();
@@ -160,23 +200,34 @@ static void ws2812_write_led2(uint16_t led_number, uint8_t r, uint8_t g, uint8_t
         sys_safe_access_disable();
     } while (R8_SLP_CLK_OFF0 & RB_SLP_CLK_TMR2);
 #endif
+    ws2812_last_leds2[led_number].r = r;
+    ws2812_last_leds2[led_number].g = g;
+    ws2812_last_leds2[led_number].b = b;
+    ws2812_debug("strip2[%u]=%u,%u,%u\n", led_number, r, g, b);
     for (uint8_t bit = 0; bit < 8; bit++) {
-        ws2812_frame_buffer2[WS2812_RED_BIT_STRIP(led_number, bit)]   = ((r >> bit) & 0x01) ? WS2812_DUTYCYCLE_1 : WS2812_DUTYCYCLE_0;
+        ws2812_frame_buffer2[WS2812_RED_BIT_STRIP(led_number, bit)] = ((r >> bit) & 0x01) ? WS2812_DUTYCYCLE_1 : WS2812_DUTYCYCLE_0;
         ws2812_frame_buffer2[WS2812_GREEN_BIT_STRIP(led_number, bit)] = ((g >> bit) & 0x01) ? WS2812_DUTYCYCLE_1 : WS2812_DUTYCYCLE_0;
-        ws2812_frame_buffer2[WS2812_BLUE_BIT_STRIP(led_number, bit)]  = ((b >> bit) & 0x01) ? WS2812_DUTYCYCLE_1 : WS2812_DUTYCYCLE_0;
+        ws2812_frame_buffer2[WS2812_BLUE_BIT_STRIP(led_number, bit)] = ((b >> bit) & 0x01) ? WS2812_DUTYCYCLE_1 : WS2812_DUTYCYCLE_0;
     }
 }
 
-void ws2812_init(void) {
+void ws2812_init(void)
+{
     uint32_t i;
     for (i = 0; i < WS2812_COLOR_BIT_N1; i++) {
         ws2812_frame_buffer1[i] = WS2812_DUTYCYCLE_0;
+    }
+    for (i = 0; i < WS2812_LED_COUNT_1; i++) {
+        ws2812_last_leds1[i] = (rgb_led_t){ 0 };
     }
     for (i = 0; i < WS2812_RESET_BIT_N; i++) {
         ws2812_frame_buffer1[i + WS2812_COLOR_BIT_N1] = 0;
     }
     for (i = 0; i < WS2812_COLOR_BIT_N2; i++) {
         ws2812_frame_buffer2[i] = WS2812_DUTYCYCLE_0;
+    }
+    for (i = 0; i < WS2812_LED_COUNT_2; i++) {
+        ws2812_last_leds2[i] = (rgb_led_t){ 0 };
     }
     for (i = 0; i < WS2812_RESET_BIT_N; i++) {
         ws2812_frame_buffer2[i + WS2812_COLOR_BIT_N2] = 0;
@@ -196,7 +247,8 @@ void ws2812_init(void) {
     WS2812_PWM_DMA_INTERRUPT_ENABLE2;
 }
 
-void ws2812_setleds_pwm1(rgb_led_t *ledarray, uint16_t leds) {
+void ws2812_setleds_pwm1(rgb_led_t *ledarray, uint16_t leds)
+{
     if (!ws2812_power_get()) {
         ws2812_power_toggle(true);
     }
@@ -209,7 +261,8 @@ void ws2812_setleds_pwm1(rgb_led_t *ledarray, uint16_t leds) {
     WS2812_PWM_DMA_INTERRUPT_SET1;
 }
 
-void ws2812_setleds_pwm2(rgb_led_t *ledarray, uint16_t leds) {
+void ws2812_setleds_pwm2(rgb_led_t *ledarray, uint16_t leds)
+{
     if (!ws2812_power_get()) {
         ws2812_power_toggle(true);
     }
@@ -222,7 +275,8 @@ void ws2812_setleds_pwm2(rgb_led_t *ledarray, uint16_t leds) {
     WS2812_PWM_DMA_INTERRUPT_SET2;
 }
 
-void ws2812_setleds(rgb_led_t *ledarray, uint16_t leds) {
+void ws2812_setleds(rgb_led_t *ledarray, uint16_t leds)
+{
     if (leds == 0) {
         return;
     }
@@ -233,4 +287,3 @@ void ws2812_setleds(rgb_led_t *ledarray, uint16_t leds) {
         ws2812_setleds_pwm2(&ledarray[WS2812_LED_COUNT_1], leds - WS2812_LED_COUNT_1);
     }
 }
-

--- a/qmk_porting/drivers/ws2812/ws2812_supplement.h
+++ b/qmk_porting/drivers/ws2812/ws2812_supplement.h
@@ -27,3 +27,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 void ws2812_power_toggle(bool status);
 bool ws2812_power_get();
+void ws2812_debug_toggle(void);
+void ws2812_debug_dump_strip1(void);

--- a/qmk_porting/keyboards/imk64/keymaps/default/keymap.c
+++ b/qmk_porting/keyboards/imk64/keymaps/default/keymap.c
@@ -16,6 +16,27 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include QMK_KEYBOARD_H
+#include "ws2812_supplement.h"
+
+enum custom_keycodes {
+    WS2812_DBG_TOG = SAFE_RANGE,
+    WS2812_DBG_DUMP,
+};
+
+bool process_record_user(uint16_t keycode, keyrecord_t *record)
+{
+    if (record->event.pressed) {
+        switch (keycode) {
+            case WS2812_DBG_TOG:
+                ws2812_debug_toggle();
+                return false;
+            case WS2812_DBG_DUMP:
+                ws2812_debug_dump_strip1();
+                return false;
+        }
+    }
+    return true;
+}
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [0] = LAYOUT_all(/* 0: qwerty */
                      KC_ESC, KC_1, KC_2, KC_3, KC_4, KC_5, KC_6, KC_7, KC_8, KC_9, KC_0, KC_MINS, KC_EQL, KC_BSPC,
@@ -25,7 +46,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
                      KC_LCTL, KC_LGUI, KC_LALT, KC_SPC, KC_RALT, MO(1), KC_LEFT, KC_DOWN, KC_RIGHT),
     [1] = LAYOUT_all(/* 1: fn */
                      KC_GRV, KC_F1, KC_F2, KC_F3, KC_F4, KC_F5, KC_F6, KC_F7, KC_F8, KC_F9, KC_F10, KC_F11, KC_F12, KC_DELETE,
-                     _______, _______, KC_UP, _______, _______, _______, _______, KC_INSERT, KC_HOME, KC_PAGE_UP, _______, _______, _______, _______,
+                     _______, _______, KC_UP, _______, _______, _______, _______, WS2812_DBG_TOG, WS2812_DBG_DUMP, KC_PAGE_UP, _______, _______, _______, _______,
                      _______, KC_LEFT, KC_DOWN, KC_RGHT, _______, _______, _______, KC_DELETE, KC_END, KC_PAGE_DOWN, _______, _______, _______,
                      _______, RGB_TOG, RGB_MOD, RGB_HUI, RGB_HUD, RGB_SAI, RGB_SAD, RGB_VAI, RGB_VAD, KC_VOLD, KC_VOLU, KC_MUTE, KC_MPLY, KC_MSTP,
                      _______, _______, _______, _______, _______, _______, _______, _______, _______),


### PR DESCRIPTION
## Summary
- Restore per-LED ws2812 writer and track last colors for diagnostics
- Add runtime debug toggle and strip1 dump functions with keymap access

## Testing
- `./build.sh` *(fails: Could not find CMAKE_C_COMPILER using the following names: riscv-wch-elf-gcc)*

------
https://chatgpt.com/codex/tasks/task_e_68b1fedfb9948330852daff597abd1ae